### PR TITLE
Exp script improvement

### DIFF
--- a/scripts/sosp24-experiments/vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/vm_flows_exp.sh
@@ -126,50 +126,45 @@ fi
 iommu_config="host-${host_iommu_config}-guest-${guest_iommu_config}-$virt_tech"
 echo "iommu_config: $iommu_config"
 
-# pause the frame
-sudo ethtool --pause $GUEST_INTF tx off rx off
-$SSH_CLIENT_CMD "sudo ethtool --pause $CLIENT_INTF tx off rx off"
-$SSH_CLIENT_CMD "echo off | sudo tee /sys/devices/system/cpu/smt/control"
-
-sleep 1
 
 client_cores="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
 server_cores="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
 
 timestamp=$(date '+%Y-%m-%d-%H-%M-%S')
+N_RUNS=3
 for socket_buf in 1; do
     for ring_buffer in 512; do
-        for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32; do
-        #for i in 16 24; do
-            num_cores=$i
-            client_cores_mask=($(echo $client_cores | tr ',' '\n' | head -n $num_cores | tr '\n' ','))
-            server_cores_mask=($(echo $server_cores | tr ',' '\n' | head -n $num_cores | tr '\n' ','))
+        for i in 1; do
+            # for num_cores in 1 4 8 12 16 20 24; do
+            for num_cores in 16; do
+                client_cores_mask=($(echo $client_cores | tr ',' '\n' | head -n $num_cores | tr '\n' ','))
+                server_cores_mask=($(echo $server_cores | tr ',' '\n' | head -n $num_cores | tr '\n' ','))
 
-      	    format_i=$(printf "%02d\n" $i)
-            exp_name="${timestamp}-$(uname -r)-flow${format_i}-${iommu_config}-${num_cores}cores"
-            echo $exp_name
+                n_val=$(( i * num_cores ))
+                # echo $n_val
+                format_i=$(printf "%02d\n" $n_val)
+                exp_name="${timestamp}-$(uname -r)-flow${format_i}-${iommu_config}-${num_cores}cores"
+                echo "Run $exp_name ($N_RUNS runs)..."
 
-            if [ "$DRY_RUN" -eq 1 ]; then
-                continue
-            fi
+                if [ "$DRY_RUN" -eq 1 ]; then
+                    continue
+                fi
 
-            sudo bash vm-run-dctcp-tput-experiment.sh \
-            --guest-home "$GUEST_HOME" --guest-ip "$GUEST_IP" --guest-intf "$GUEST_INTF" --guest-bus "$GUEST_NIC_BUS" -n "$i" -c $server_cores_mask \
-            --client-home "$CLIENT_HOME" --client-ip "$CLIENT_IP" --client-intf "$CLIENT_INTF" -N "$i" -C $client_cores_mask \
-            --host-home "$HOST_HOME" --host-ip "$HOST_IP" \
-            --client-ssh-name "$CLIENT_SSH_UNAME" --client-ssh-pass "$CLIENT_SSH_PASSWORD" --client-ssh-host "$CLIENT_SSH_HOST" --client-ssh-use-pass "$CLIENT_USE_PASS_AUTH" --client-ssh-ifile "$CLIENT_SSH_IDENTITY_FILE" \
-            -e "$exp_name" -m 4000 -r $ring_buffer -b "400g" -d 1\
-            --socket-buf $socket_buf --mlc-cores 'none' --runs 3
+                sudo bash vm-run-dctcp-tput-experiment.sh \
+                    --guest-home "$GUEST_HOME" --guest-ip "$GUEST_IP" --guest-intf "$GUEST_INTF" --guest-bus "$GUEST_NIC_BUS" -n "$n_val" -c $server_cores_mask \
+                    --client-home "$CLIENT_HOME" --client-ip "$CLIENT_IP" --client-intf "$CLIENT_INTF" -N "$n_val" -C $client_cores_mask \
+                    --host-home "$HOST_HOME" --host-ip "$HOST_IP" \
+                    --client-ssh-name "$CLIENT_SSH_UNAME" --client-ssh-pass "$CLIENT_SSH_PASSWORD" --client-ssh-host "$CLIENT_SSH_HOST" --client-ssh-use-pass "$CLIENT_USE_PASS_AUTH" --client-ssh-ifile "$CLIENT_SSH_IDENTITY_FILE" \
+                    -e "$exp_name" -m 4000 -r $ring_buffer -b "400g" -d 1\
+                    --socket-buf $socket_buf --mlc-cores 'none' --runs $N_RUNS
 
-            python3 report-tput-metrics.py $exp_name tput,drops,acks,iommu,cpu | sudo tee ../utils/reports/$exp_name/summary.txt
-            echo $PWD
-            cd ../utils/reports/$exp_name
+                python3 report-tput-metrics.py $exp_name tput,drops,acks,iommu,cpu | sudo tee ../utils/reports/$exp_name/summary.txt
+                echo $PWD
+                cd ../utils/reports/$exp_name
 
-            sudo bash -c "cat /sys/kernel/debug/tracing/trace > iova.log"
-
-            cd -
-            sudo chmod +666 -R ../utils/reports/$exp_name
-
+                cd -
+                sudo chmod +666 -R ../utils/reports/$exp_name
+            done
         done
     done
 done

--- a/scripts/vm-collect-tput-stats.py
+++ b/scripts/vm-collect-tput-stats.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 import statistics
 import subprocess
+import os
 
 # TODO: Leshna, Combine both vm and baremetal stat collector with file names as parameters.
 
@@ -59,19 +60,24 @@ for i in range(NUM_RUNS):
                 sent = float(line_str[-1])
                 sent_packets.append(sent)
 
-    with open(FILE_NAME + '-RUN-' + str(i) + '/host-membw.rpt') as f1:
-        try:
-            for line in f1:
-                line_str = line.split()
-                if (line_str[0] != 'Node0_total_bw:'):
-                    continue
-                else:
-                    membw = float(line_str[-1])
-                    if (membw >= 0):
-                        mem_bws.append(membw)
-                    break
-        except Exception as e:
-            mem_bws.append(0)
+    host_membw_file = FILE_NAME + '-RUN-' + str(i) + '/host-membw.rpt'
+    if os.path.exists(host_membw_file):
+        with open(FILE_NAME + '-RUN-' + str(i) + '/host-membw.rpt') as f1:
+            try:
+                for line in f1:
+                    line_str = line.split()
+                    if (line_str[0] != 'Node0_total_bw:'):
+                        continue
+                    else:
+                        membw = float(line_str[-1])
+                        if (membw >= 0):
+                            mem_bws.append(membw)
+                        break
+            except Exception as e:
+                mem_bws.append(0)
+    else:
+        mem_bws.append(0)
+        print(f"[WARN] Host membw file not found: {host_membw_file}")
 
     with open(FILE_NAME + '-RUN-' + str(i) + '/cpu_util.rpt') as f1:
         for line in f1:

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -543,7 +543,8 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     host_logging_cmd="cd '$HOST_SETUP_DIR'; sudo bash record-host-metrics.sh \
         --dep '$HOST_RESULTS_DIR' -o '${EXP_NAME}-RUN-${j}' --dur '$CORE_DURATION_S' \
         --cpu-util 0 --retx 1 --tcplog 0 --bw 1 --flame 0 \
-        --pcie 1 --membw 1 --iio 1 --pfc 0 --type 0; exec bash"
+        --pcie 1 --membw 0 --iio 0 --pfc 0 --type 0; exec bash"
+        # --pcie 1 --membw 0 --iio 0 --pfc 0 --type 0; exec bash"
     echo $host_logging_cmd
     $SSH_HOST_CMD "screen -dmS logging_session_host sudo bash -c \"$host_logging_cmd\""
 
@@ -551,7 +552,8 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     cd "$GUEST_SETUP_DIR" || { log_error "Failed to cd to $GUEST_SETUP_DIR"; exit 1; }
     sudo bash record-host-metrics.sh --dep "$GUEST_HOME" -o "${EXP_NAME}-RUN-${j}" \
     --dur "$CORE_DURATION_S" --cpu-util 1 -c "$GUEST_CPU_MASK" --retx 1 --tcplog 0 --bw 1 --flame 0 \
-    --pcie 0 --membw 1 --iio 1 --pfc 0 --intf "$GUEST_INTF" --type 0
+    --pcie 0 --membw 0 --iio 0 --pfc 0 --intf "$GUEST_INTF" --type 0
+    # --pcie 0 --membw 1 --iio 1 --pfc 0 --intf "$GUEST_INTF" --type 0
     cd - > /dev/null
 
     log_info "Logging done."
@@ -605,9 +607,9 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
         sshpass -p $HOST_SSH_PASSWORD scp \
         "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/pcie.rpt" \
         "${current_guest_reports_dir}/host-pcie.rpt" || log_error "Failed to SCP host pcie.rpt"
-        sshpass -p $HOST_SSH_PASSWORD scp \
-        "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/membw.rpt" \
-        "${current_guest_reports_dir}/host-membw.rpt" || log_error "Failed to SCP host membw.rpt"
+        # sshpass -p $HOST_SSH_PASSWORD scp \
+        # "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/membw.rpt" \
+        # "${current_guest_reports_dir}/host-membw.rpt" || log_error "Failed to SCP host membw.rpt"
     else
     	scp -i "$HOST_SSH_IDENTITY_FILE" \
         "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/retx.rpt" \
@@ -615,9 +617,9 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     	scp -i "$HOST_SSH_IDENTITY_FILE" \
         "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/pcie.rpt" \
         "${current_guest_reports_dir}/host-pcie.rpt" || log_error "Failed to SCP host pcie.rpt (${host_reports_dir_remote}/pcie.rpt)"
-    	scp -i "$HOST_SSH_IDENTITY_FILE" \
-        "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/membw.rpt" \
-        "${current_guest_reports_dir}/host-membw.rpt" || log_error "Failed to SCP host membw.rpt (${host_reports_dir_remote}/membw.rpt)"
+    	# scp -i "$HOST_SSH_IDENTITY_FILE" \
+        # "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/membw.rpt" \
+        # "${current_guest_reports_dir}/host-membw.rpt" || log_error "Failed to SCP host membw.rpt (${host_reports_dir_remote}/membw.rpt)"
     fi
     # SCP profiling data to host (as guest has limited space)
     # sudo sshpass -p "$HOST_SSH_PASSWORD" scp "$perf_guest_data_file" "${HOST_SSH_UNAME}@${HOST_IP}:${host_reports_dir_remote}/perf_guest_cpu.data"

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -17,7 +17,8 @@ PERF_TRACING_ENABLED=0
 PERF_TRACING_HOST_ENABLED=1
 
 # --- Base Directory Paths (Relative to respective home directories) ---
-GUEST_FandS_REL="viommu_siyuan"
+SCRIPT_DIR=$(dirname "$0")
+GUEST_FandS_REL=$(basename $(realpath "$SCRIPT_DIR/../"))
 GUEST_PERF_REL="linux-6.12.9/tools/perf/perf" # TODO: Siyuan change for your directory
 CLIENT_FandS_REL="Fast-and-Safe-IO-Memory-Protection"
 HOST_FandS_REL="viommu/Fast-and-Safe-IO-Memory-Protection"

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -412,7 +412,7 @@ save_vm_config_to_report() {
     done
 }
 
-pre_exp_cleanup
+pre_exp_setup
 
 log_info "Starting experiment: $EXP_NAME"
 log_info "Number of runs: $NUM_RUNS"

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -213,11 +213,11 @@ else
 fi
 
 log_info() {
-    echo "[INFO] - $1"
+    echo "[INFO-$(date +%Y-%m-%d-%H:%M:%S)] - $1"
 }
 
 log_error() {
-    echo "[ERROR] - $1" >&2
+    echo "[ERROR-$(date +%Y-%m-%d-%H:%M:%S)] - $1" >&2
 }
 
 progress_bar() {
@@ -254,6 +254,36 @@ progress_bar() {
 }
 
 # --- Cleanup Function ---
+pre_exp_setup() {
+    log_info "--- Starting Pre-experiment Cleanup Phase ---"
+
+    log_info "Disabling TX/RX on GUEST and CLIENT"
+    sudo ethtool --pause $GUEST_INTF tx off rx off
+    $SSH_CLIENT_CMD "sudo ethtool --pause $CLIENT_INTF tx off rx off"
+    
+    log_info "Disabling SMT on Client"
+    $SSH_CLIENT_CMD "echo off | sudo tee /sys/devices/system/cpu/smt/control"
+
+    # Host's smt, cpu power, numa balance will be setup in setup-host.sh
+    log_info "--- Pre-experiment Cleanup Phase Finished ---"
+}
+
+post_exp_cleanup() {
+    log_info "--- Starting Post-experiment Cleanup Phase ---"
+    
+    log_info "Resetting GUEST ftrace..."
+    sudo echo 0 > /sys/kernel/debug/tracing/tracing_on
+    sudo echo 0 > /sys/kernel/debug/tracing/options/overwrite
+    sudo echo 20000 > /sys/kernel/debug/tracing/buffer_size_kb
+
+    log_info "Resetting HOST..."
+    $SSH_HOST_CMD \
+        "cd '$HOST_SETUP_DIR'; sudo bash reset-host.sh"
+    
+    log_info "--- Post-experiment Cleanup Phase Finished ---"
+}
+
+
 cleanup() {
     log_info "--- Starting Cleanup Phase ---"
 
@@ -301,20 +331,7 @@ cleanup() {
     $SSH_HOST_CMD \
         'screen -wipe || true'
 
-    log_info "Resetting GUEST ftrace..."
-    sudo echo 0 > /sys/kernel/debug/tracing/tracing_on
-    sudo echo 0 > /sys/kernel/debug/tracing/options/overwrite
-    sudo echo 20000 > /sys/kernel/debug/tracing/buffer_size_kb
-
-    log_info "Resetting HOST..."
-    $SSH_HOST_CMD \
-        "cd '$HOST_SETUP_DIR'; sudo bash reset-host.sh"
-
-    log_info "Resetting GUEST network interface $GUEST_INTF..."
-    sudo ip link set "$GUEST_INTF" down
-    sleep 2
-    sudo ip link set "$GUEST_INTF" up
-    sleep 2
+    sleep 1
     log_info "--- Cleanup Phase Finished ---"
 }
 
@@ -394,6 +411,8 @@ save_vm_config_to_report() {
         fi
     done
 }
+
+pre_exp_cleanup
 
 log_info "Starting experiment: $EXP_NAME"
 log_info "Number of runs: $NUM_RUNS"
@@ -545,6 +564,9 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     sudo echo > /sys/kernel/debug/tracing/trace # Clear buffer after saving
     log_info "GUEST IOVA ftrace data saved to $iova_ftrace_guest_output_file"
 
+    head -n 2000 $iova_ftrace_guest_output_file > $iova_ftrace_guest_output_file.head2000
+    tail -n 2000 $iova_ftrace_guest_output_file > $iova_ftrace_guest_output_file.tail2000
+
     log_info "Stopping and saving HOST IOVA ftrace data on $HOST_IP..."
     $SSH_HOST_CMD \
         "sudo bash -c 'sudo echo 0 > /sys/kernel/debug/tracing/tracing_on; \
@@ -604,14 +626,15 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     log_info "Waiting for remote operations and data transfers to settle (original sleep: $(($CORE_DURATION_S * 2))s)..."
     progress_bar $((CORE_DURATION_S * 2)) 2
 
-    # --- Post-run cleanup ---
-    cleanup
     log_info "############################################################"
     log_info "### Finished Experiment Run: $j / $(($NUM_RUNS - 1))"
     log_info "############################################################"
     echo # Blank line
 done
 
+# --- Post-run cleanup ---
+cleanup
+post_exp_cleanup
 
 if [ "$MLC_CORES" != "none" ]; then
     log_info "MLC cores were used. The original script had a second phase for MLC throughput which is currently skipped."


### PR DESCRIPTION
Better experiment script
- Dynamically define `GUEST_FandS_REL` based on relative position of `scripts/vm-run-dctcp-tput-experiment.sh` https://github.com/xlab-uiuc/Fast-and-Safe-IO-Memory-Protection/commit/8a2e25cc383d8eb6c772ba0f02178a1e9310c28b

Faster experiment
- Remove reset-host.sh from cleanup. Most importantly, smt toggling is removed. Add pre-exp-setup and post-exp-cleanup https://github.com/xlab-uiuc/Fast-and-Safe-IO-Memory-Protection/commit/d3d7ef2ecdc8c242e34a5d09f11b7bf378f404fa
  - Before change 12m17.211s([original.log](https://github.com/user-attachments/files/24403458/original.log)). After change ([presetup.log](https://github.com/user-attachments/files/24403457/presetup.log)). Tested with 16 cores and 16 flows, three runs.
- Remove membw and IIO logging on guest and host. The metrics are not useful now. https://github.com/xlab-uiuc/Fast-and-Safe-IO-Memory-Protection/pull/23/commits/73473fe5f51e4a1b03ba14dc940e54c2a3e1928f
  - Before change 8m40.780s. After change 7m16.969s ([no_membw_iio.log](https://github.com/user-attachments/files/24403459/no_membw_iio.log)).  


