### PR TITLE
Fix per cpu BPF. Avoid extraordinarily large number of latency measurement

### DIFF
--- a/tracing/guest_loader.c
+++ b/tracing/guest_loader.c
@@ -283,7 +283,7 @@ static void dump_aggregate_to_file(FILE *fp, struct guest_tracer_bpf *skel)
     const char *fn_name = func_name_to_string((enum FunctionName)fn);
     size_t per_cpu_sz = sizeof(struct latency_stats_t);
     size_t buf_sz = per_cpu_sz * num_cpus;
-    struct latency_stats_t *percpu_stats = malloc(buf_sz);
+    struct latency_stats_t *percpu_stats = calloc(1, buf_sz);
     if (!percpu_stats || bpf_map_lookup_elem(stats_fd, &fn, percpu_stats) != 0) {
       free(percpu_stats);
       continue;
@@ -349,7 +349,7 @@ static void dump_aggregate_to_file(FILE *fp, struct guest_tracer_bpf *skel)
   for (int fn = TRACE_FUNCS_END; fn < FUNCTION_NAME_MAX; fn++) {
     const char *fn_name = func_name_to_string((enum FunctionName)fn);
     size_t counts_sz = sizeof(__u64) * num_cpus;
-    __u64 *percpu_counts = malloc(counts_sz);
+    __u64 *percpu_counts = calloc(1, counts_sz);
     if (!percpu_counts || bpf_map_lookup_elem(counts_fd, &fn, percpu_counts) != 0) {
       free(percpu_counts);
       continue;
@@ -394,7 +394,7 @@ static void dump_aggregate_to_file(FILE *fp, struct guest_tracer_bpf *skel)
     for (int bucket = 0; bucket < HISTO_BUCKETS; bucket++) {
       u32 histo_key = fn * HISTO_BUCKETS + bucket;
       size_t counts_sz = sizeof(__u64) * num_cpus;
-      __u64 *percpu_counts = malloc(counts_sz);
+      __u64 *percpu_counts = calloc(1, counts_sz);
       if (!percpu_counts || bpf_map_lookup_elem(histo_fd, &histo_key, percpu_counts) != 0) {
         free(percpu_counts);
         continue;

--- a/tracing/guest_tracer.bpf.c
+++ b/tracing/guest_tracer.bpf.c
@@ -10,13 +10,16 @@ char LICENSE[] SEC("license") = "GPL";
 #define SAMPLE_RATE_POW2 1024
 #define SAMPLE_MASK (SAMPLE_RATE_POW2 - 1)
 
-struct
-{
-  __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-  __uint(max_entries, 16384);
-  __type(key, struct entry_key_t);
-  __type(value, struct entry_val_t);
-} entry_traces SEC(".maps");
+struct task_trace_data_t {
+    u64 start_times[TRACE_FUNCS_END];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+    __type(key, int);
+    __type(value, struct task_trace_data_t);
+} task_storage SEC(".maps");
 
 struct
 {
@@ -55,20 +58,20 @@ static __always_inline u32 log2_u64(u64 v)
 static __always_inline int
 _bpf_utils_trace_func_entry(struct pt_regs *ctx)
 {
-  // u32 rnd = bpf_get_prandom_u32();
-  // if (rnd & SAMPLE_MASK)
-  //   return 0;
-  
   u64 cookie = bpf_get_attach_cookie(ctx);
 
   if (cookie >= TRACE_FUNCS_END) {
     return 0;
   }
 
-  u64 pid_tgid = bpf_get_current_pid_tgid();
-  struct entry_key_t key = {.id = pid_tgid, .cookie = cookie};
-  struct entry_val_t val = {.ts = bpf_ktime_get_ns()};
-  return bpf_map_update_elem(&entry_traces, &key, &val, BPF_ANY);
+  struct task_struct *task = bpf_get_current_task_btf();
+  struct task_trace_data_t *data = bpf_task_storage_get(&task_storage, task, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+  
+  if (!data)
+      return 0;
+
+  data->start_times[cookie] = bpf_ktime_get_ns();
+  return 0;
 }
 
 static __always_inline int
@@ -86,22 +89,31 @@ _bpf_utils_trace_func_exit(struct pt_regs *ctx, enum Domain domain, bool is_upro
     return 0;
   }
 
-  u64 pid_tgid = bpf_get_current_pid_tgid();
-  struct entry_key_t key = {.id = pid_tgid, .cookie = cookie};
-  struct entry_val_t *entry_val_p;
+  struct task_struct *task = bpf_get_current_task_btf();
+  struct task_trace_data_t *data = bpf_task_storage_get(&task_storage, task, 0, 0);
 
-  entry_val_p = bpf_map_lookup_elem(&entry_traces, &key);
-  if (!entry_val_p) {
-    return 0;
-  }
+  if (!data)
+      return 0;
+
+  u64 start_ts = data->start_times[cookie];
+  if (start_ts == 0)
+      return 0;
+
+  // Clear it (optional, but good practice)
+  data->start_times[cookie] = 0;
 
   u64 duration_ns;
   u64 duration_us;
-  // bool is_sampled_event;
   u32 func_enum_key;
 
-  duration_ns = bpf_ktime_get_ns() - entry_val_p->ts;
-  func_enum_key = (u32)key.cookie;
+  duration_ns = bpf_ktime_get_ns() - start_ts;
+  func_enum_key = (u32)cookie;
+
+  // Sanity check: if duration is larger than 1 second, it's likely a stale entry
+  // or something went wrong.
+  if (duration_ns > 1000000000ULL) {
+      return 0;
+  }
 
   struct latency_stats_t *stats = bpf_map_lookup_elem(&func_latency_stats, &func_enum_key);
   if (stats) {
@@ -125,7 +137,6 @@ _bpf_utils_trace_func_exit(struct pt_regs *ctx, enum Domain domain, bool is_upro
     }   
   }
         
-  bpf_map_delete_elem(&entry_traces, &key);
   return 0;
 }
 


### PR DESCRIPTION
Problem with previous start times tracking with BPF_MAP_TYPE_PERCPU_HASH map.

> The Leak (First Run):
> Task A starts on CPU 0. It creates an entry in CPU 0's map: {PID: 100, Start: 1000ns}.
> Task A migrates to CPU 1.
> Task A ends on CPU 1.
> Your Check: lookup(CPU 1) returns NULL. Your code returns 0.
> The Problem: The entry on CPU 0 was never deleted. It is now a "landmine" with an old timestamp (1000ns).
> The Explosion (Second Run):
> Some time later, Task A (same PID) runs again.
> It starts on CPU 1. It creates an entry in CPU 1's map.
> It migrates back to CPU 0.
> It ends on CPU 0.
> The Lookup: It looks up PID 100 on CPU 0.
> The Bug: It finds the stale entry from Step 1 (timestamp 1000ns).
> The Calculation: Duration = Now (e.g., 5,000,000ns) - Old_Start (1000ns).
> Result: A massive, incorrect latency (4,999,000ns).
