### PR TITLE
Lock Contention Memory Collection

### DIFF
--- a/scripts/collect-mem-stats.sh
+++ b/scripts/collect-mem-stats.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Path to place resulting CSV file,
+# this is the first argument passed to this script
+# If not provided, it defaults to "memory_stats.csv" in the current directory
+OUT="${1:-memory_stats.csv}"
+
+# Time to wait between samples (in seconds)
+WAIT=5
+
+# Write header once
+if [[ ! -f "$OUT" ]]; then
+  echo "timestamp,mem_total,mem_used,mem_free,mem_shared,mem_buff_cache,mem_available,swap_total,swap_used,swap_free" > "$OUT"
+fi
+
+while true; do
+  ts="$(date -Iseconds)"
+  free -b | awk -v ts="$ts" '/^Mem:/{m=$2","$3","$4","$5","$6","$7} /^Swap:/{s=$2","$3","$4} END{print ts","m","s}' >> "$OUT"
+  sleep "$WAIT"
+done

--- a/scripts/collect-mem-stats.sh
+++ b/scripts/collect-mem-stats.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 OUT="${1:-memory_stats.csv}"
 
 # Time to wait between samples (in seconds)
-WAIT=5
+WAIT="${2:-1}"
 
 # Write header once
 if [[ ! -f "$OUT" ]]; then

--- a/scripts/sosp24-experiments/vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/vm_flows_exp.sh
@@ -126,11 +126,14 @@ fi
 iommu_config="host-${host_iommu_config}-guest-${guest_iommu_config}-$virt_tech"
 echo "iommu_config: $iommu_config"
 
-
 client_cores="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
 server_cores="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
 
 timestamp=$(date '+%Y-%m-%d-%H-%M-%S')
+
+echo "Starting memory collection script..."
+sudo bash collect-mem-stats.sh "../utils/reports/${timestamp}-mem-stats-${iommu_config}.csv" &
+
 N_RUNS=3
 for socket_buf in 1; do
     for ring_buffer in 512; do

--- a/scripts/sosp24-experiments/vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/vm_flows_exp.sh
@@ -150,13 +150,6 @@ for socket_buf in 1; do
                     continue
                 fi
 
-                mkdir -p ../utils/reports/$exp_name
-
-                echo "Starting memory collection script..."
-                sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" &
-                mem_pid=$!
-                echo "Memory collection started with PID $mem_pid"
-
                 sudo bash vm-run-dctcp-tput-experiment.sh \
                     --guest-home "$GUEST_HOME" --guest-ip "$GUEST_IP" --guest-intf "$GUEST_INTF" --guest-bus "$GUEST_NIC_BUS" -n "$n_val" -c $server_cores_mask \
                     --client-home "$CLIENT_HOME" --client-ip "$CLIENT_IP" --client-intf "$CLIENT_INTF" -N "$n_val" -C $client_cores_mask \
@@ -164,9 +157,6 @@ for socket_buf in 1; do
                     --client-ssh-name "$CLIENT_SSH_UNAME" --client-ssh-pass "$CLIENT_SSH_PASSWORD" --client-ssh-host "$CLIENT_SSH_HOST" --client-ssh-use-pass "$CLIENT_USE_PASS_AUTH" --client-ssh-ifile "$CLIENT_SSH_IDENTITY_FILE" \
                     -e "$exp_name" -m 4000 -r $ring_buffer -b "400g" -d 1\
                     --socket-buf $socket_buf --mlc-cores 'none' --runs $N_RUNS
-
-                echo "Experiment completed, killing memory collection with PID $mem_pid"
-                sudo kill "$mem_pid"
 
                 python3 report-tput-metrics.py $exp_name tput,drops,acks,iommu,cpu | sudo tee ../utils/reports/$exp_name/summary.txt
                 echo $PWD

--- a/scripts/sosp24-experiments/vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/vm_flows_exp.sh
@@ -131,9 +131,6 @@ server_cores="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,2
 
 timestamp=$(date '+%Y-%m-%d-%H-%M-%S')
 
-echo "Starting memory collection script..."
-sudo bash collect-mem-stats.sh "../utils/reports/${timestamp}-mem-stats-${iommu_config}.csv" &
-
 N_RUNS=3
 for socket_buf in 1; do
     for ring_buffer in 512; do
@@ -153,6 +150,11 @@ for socket_buf in 1; do
                     continue
                 fi
 
+                echo "Starting memory collection script..."
+                sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" &
+                mem_pid=$!
+                echo "Memory collection started with PID $mem_pid"
+
                 sudo bash vm-run-dctcp-tput-experiment.sh \
                     --guest-home "$GUEST_HOME" --guest-ip "$GUEST_IP" --guest-intf "$GUEST_INTF" --guest-bus "$GUEST_NIC_BUS" -n "$n_val" -c $server_cores_mask \
                     --client-home "$CLIENT_HOME" --client-ip "$CLIENT_IP" --client-intf "$CLIENT_INTF" -N "$n_val" -C $client_cores_mask \
@@ -160,6 +162,9 @@ for socket_buf in 1; do
                     --client-ssh-name "$CLIENT_SSH_UNAME" --client-ssh-pass "$CLIENT_SSH_PASSWORD" --client-ssh-host "$CLIENT_SSH_HOST" --client-ssh-use-pass "$CLIENT_USE_PASS_AUTH" --client-ssh-ifile "$CLIENT_SSH_IDENTITY_FILE" \
                     -e "$exp_name" -m 4000 -r $ring_buffer -b "400g" -d 1\
                     --socket-buf $socket_buf --mlc-cores 'none' --runs $N_RUNS
+
+                echo "Experiment completed, killing memory collection with PID $mem_pid"
+                sudo kill "$mem_pid"
 
                 python3 report-tput-metrics.py $exp_name tput,drops,acks,iommu,cpu | sudo tee ../utils/reports/$exp_name/summary.txt
                 echo $PWD

--- a/scripts/sosp24-experiments/vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/vm_flows_exp.sh
@@ -150,6 +150,8 @@ for socket_buf in 1; do
                     continue
                 fi
 
+                mkdir -p ../utils/reports/$exp_name
+
                 echo "Starting memory collection script..."
                 sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" &
                 mem_pid=$!

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -477,7 +477,7 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     save_vm_config_to_report "$current_guest_reports_dir"
 
     log_info "Starting memory collection script..."
-    sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" 0.5 &
+    sudo bash collect-mem-stats.sh "$current_guest_reports_dir/memory_stats.csv" 0.5 &
     mem_pid=$!
     log_info "Memory collection started with PID $mem_pid"
 

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -477,7 +477,7 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     save_vm_config_to_report "$current_guest_reports_dir"
 
     log_info "Starting memory collection script..."
-    sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" &
+    sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" 0.5 &
     mem_pid=$!
     log_info "Memory collection started with PID $mem_pid"
 

--- a/scripts/vm-run-dctcp-tput-experiment.sh
+++ b/scripts/vm-run-dctcp-tput-experiment.sh
@@ -476,6 +476,11 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
     save_config_to_report_json "$current_guest_reports_dir"
     save_vm_config_to_report "$current_guest_reports_dir"
 
+    log_info "Starting memory collection script..."
+    sudo bash collect-mem-stats.sh "../utils/reports/$exp_name/memory_stats.csv" &
+    mem_pid=$!
+    log_info "Memory collection started with PID $mem_pid"
+
     # --- Start MLC (Memory Latency Checker) if configured ---
     if [ "$MLC_CORES" != "none" ]; then
         log_info "Starting MLC on cores: $MLC_CORES; logs at $guest_mlc_log_file..."
@@ -584,6 +589,10 @@ for ((j = 0; j < NUM_RUNS; j += 1)); do
 
     log_info "Logging done."
     log_info "Primary data collection phase on GUEST complete."
+
+    log_info "Killing memory collection with PID $mem_pid"
+    sudo kill "$mem_pid"
+
 
     # --- Save Ftrace Data (Guest & Host) ---
     log_info "Stopping and saving GUEST IOVA ftrace data..."


### PR DESCRIPTION
I added a script that will collect memory stats from `free` and save it into a CSV file in the reports directory. It's saved to a file called `mem_stats.csv` in the respective experiment directory. It runs in the background as the benchmark is running, and gets killed once the experiment is finished. It collects data every 5 seconds by default, but this can be configured.

Currently untested as of now but once nexus frees up I will test and make any required fixes.