### PR TITLE
Many vm setup siyuan

### DIFF
--- a/multi_vms/run_all.sh
+++ b/multi_vms/run_all.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VIOMMU_MODES=("off" "nested" "nested-vFree")
+
+# --- Experiment configurations ---
+#   (num_vms, num_total_cores, num_active_cores, num_flows)
+#   num_flows = num_active_cores per VM
+CONFIGS=(
+	"2  16 15 15"
+	"2  16 16 16"
+	"4  8  7  7"
+	"4  8  8  8"
+	"8  4  3  3"
+	"8  4  4  4"
+)
+
+run_idx=0
+total=$((${#CONFIGS[@]} * ${#VIOMMU_MODES[@]}))
+
+for config in "${CONFIGS[@]}"; do
+	read -r num_vms num_total_cores num_active_cores num_flows <<< "$config"
+
+	for viommu in "${VIOMMU_MODES[@]}"; do
+		run_idx=$((run_idx + 1))
+		echo ""
+		echo "================================================================"
+		echo "  Run ${run_idx}/${total}: --viommu ${viommu} --num-vms ${num_vms}" \
+			"--num-total-cores ${num_total_cores} --num-active-cores ${num_active_cores}" \
+			"--num-flows ${num_flows}"
+		echo "================================================================"
+		echo ""
+
+		./run_vms.sh \
+			--viommu "$viommu" \
+			--num-vms "$num_vms" \
+			--num-total-cores "$num_total_cores" \
+			--num-active-cores "$num_active_cores" \
+			--num-flows "$num_flows" \
+			--skip-reset-host
+
+		rc=$?
+		if [[ $rc -ne 0 ]]; then
+			echo "WARNING: Run ${run_idx} failed (exit $rc), continuing..."
+		fi
+	done
+done
+
+echo ""
+echo "================================================================"
+echo "  All ${total} experiments complete"
+echo "================================================================"

--- a/multi_vms/run_vms.sh
+++ b/multi_vms/run_vms.sh
@@ -5,22 +5,13 @@ set -euo pipefail
 # Configuration
 # ============================================================
 
-# GUEST_CMD_LINE_NESTED="root=/dev/vda2 ro console=ttyS0,115200 earlyprintk=serial,ttyS0,115200 intel_iommu=on,sm_on iommu.strict=1 intel_iommu_pinned=on intel_iommu_dfp=on"
-GUEST_CMD_LINE_NESTED="root=/dev/vda2 ro console=ttyS0,115200 earlyprintk=serial,ttyS0,115200 intel_iommu=on,sm_on iommu.strict=1"
-GUEST_CMD_LINE_OFF="root=/dev/vda2 ro console=ttyS0,115200 earlyprintk=serial,ttyS0,115200 intel_iommu=off"
-
-# GUEST_KERNEL="6.12.9-iommufd-nested-iova-contig-cb-opt"
-# GUEST_KERNEL_PATH="/boot-VM/vmlinuz-$GUEST_KERNEL"
-# GUEST_INITRD_PATH="/boot-VM/initrd.img-$GUEST_KERNEL"
-GUEST_KERNEL="6.12.9-iommufd"
-GUEST_KERNEL_PATH="/boot/vmlinuz-$GUEST_KERNEL"
-GUEST_INITRD_PATH="/boot/initrd.img-$GUEST_KERNEL"
-GUEST_VIOMMU="off" # nested/off
-NUM_VMS=12
-NUM_CORES="2"
-NUM_IPRF="1"
-NUM_FLOWS="1"
+GUEST_VIOMMU="nested-vFree" # off/nested/nested-vFree
+NUM_VMS=1
+NUM_TOTAL_CORES="16"
+NUM_ACTIVE_CORES="12"
+NUM_FLOWS="12"
 REUSE=0
+SKIP_RESET_HOST=0
 
 # --- Hardcoded experiment config ---
 GIT_REPO="/home/schai/viommu"
@@ -32,6 +23,11 @@ HOST_FandS_ABS=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
 HOST_SETUP_DIR="${HOST_FandS_ABS}/utils"
 echo "Host F&S dir: ${HOST_FandS_ABS}"
 
+# --- Host config (auto-inferred, passed to VMs so they can SCP results back) ---
+HOST_IP="192.17.101.97"
+HOST_SSH_UNAME="$(whoami)"
+HOST_HOME="$(eval echo ~$(whoami))"
+HOST_RESULTS_DIR="${HOST_FandS_ABS}/utils/reports/"
 
 # --- Client machine config ---
 CLIENT_HOME="/home/siyuanc3"
@@ -78,9 +74,8 @@ NIC_WAIT=120      # seconds to wait for guest NIC
 # --- Guest NIC interface name (SR-IOV VF) ---
 GUEST_NIC="enp0s1"
 
-# --- Host-side in-tree modules to push into guests ---
-HOST_MLX5_CORE="/lib/modules/$GUEST_KERNEL/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko"
-HOST_MLXFW="/lib/modules/$GUEST_KERNEL/kernel/drivers/net/ethernet/mellanox/mlxfw/mlxfw.ko"
+# --- Host-side in-tree modules (set after GUEST_KERNEL is resolved) ---
+# HOST_MLX5_CORE and HOST_MLXFW are set after --viommu parsing below
 
 # Save original directory
 ORIG_DIR="$(pwd)"
@@ -92,10 +87,13 @@ ORIG_DIR="$(pwd)"
 usage() {
 	cat <<-USAGE
 	Usage: $0 [OPTIONS]
-	  --num-cores N       Number of cores per VM experiment
+	  --viommu MODE       Guest vIOMMU mode: off, nested, nested-vFree (default: $GUEST_VIOMMU)
+	  --num-total-cores N    Total cores per VM
+	  --num-active-cores N   Active cores (iperf instances) per VM
 	  --num-flows N       Number of flows per VM experiment
 	  --num-vms N         Number of VMs (default: $NUM_VMS)
 	  --reuse             Reuse already-defined VMs (skip undefine/define, just start)
+	  --skip-reset-host   Skip host reset (host setup will still run)
 	  --boot-timeout N    Seconds to wait for SSH per VM (default: $BOOT_TIMEOUT)
 	  -h, --help          Show this help
 	USAGE
@@ -103,18 +101,21 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
+	--viommu)        GUEST_VIOMMU="$2"; shift 2 ;;
 	--num-vms)       NUM_VMS="$2";      shift 2 ;;
-	--num-cores)     NUM_CORES="$2";    shift 2 ;;
+	--num-total-cores)  NUM_TOTAL_CORES="$2";  shift 2 ;;
+	--num-active-cores) NUM_ACTIVE_CORES="$2"; shift 2 ;;
 	--num-flows)     NUM_FLOWS="$2";    shift 2 ;;
-	--reuse)         REUSE=1;           shift   ;;
+	--reuse)            REUSE=1;           shift   ;;
+	--skip-reset-host)  SKIP_RESET_HOST=1; shift   ;;
 	--boot-timeout)  BOOT_TIMEOUT="$2"; shift 2 ;;
 	-h|--help)       usage; exit 0      ;;
 	*)               echo "Error: unknown option '$1'" >&2; usage >&2; exit 1 ;;
 	esac
 done
 
-if [[ -z "$NUM_CORES" || -z "$NUM_FLOWS" || -z "$NUM_VMS" || -z "$NUM_IPRF" ]]; then
-	echo "Error: --num-cores, --num-flows, --num-iperf, and --num-vms are required" >&2
+if [[ -z "$NUM_TOTAL_CORES" || -z "$NUM_FLOWS" || -z "$NUM_VMS" || -z "$NUM_ACTIVE_CORES" ]]; then
+	echo "Error: --num-total-cores, --num-active-cores, --num-flows, and --num-vms are required" >&2
 	usage >&2
 	exit 1
 fi
@@ -128,12 +129,37 @@ else
 	SSH_CLIENT_CMD="ssh -i $CLIENT_SSH_IDENTITY_FILE ${CLIENT_SSH_UNAME}@${CLIENT_SSH_HOST}"
 fi
 
-GUEST_CMD_LINE=""
-if [[ "$GUEST_VIOMMU" == "nested" ]]; then
-  GUEST_CMD_LINE="$GUEST_CMD_LINE_NESTED"
-else
-  GUEST_CMD_LINE="$GUEST_CMD_LINE_OFF"
-fi
+# --- Derive guest kernel, initrd, and cmdline from vIOMMU mode ---
+GUEST_CMD_LINE_BASE="root=/dev/vda2 ro console=ttyS0,115200 earlyprintk=serial,ttyS0,115200"
+
+case "$GUEST_VIOMMU" in
+off)
+	GUEST_KERNEL="6.12.9-iommufd"
+	GUEST_KERNEL_PATH="/boot/vmlinuz-$GUEST_KERNEL"
+	GUEST_INITRD_PATH="/boot/initrd.img-$GUEST_KERNEL"
+	GUEST_CMD_LINE="$GUEST_CMD_LINE_BASE intel_iommu=off"
+	;;
+nested)
+	GUEST_KERNEL="6.12.9-iommufd"
+	GUEST_KERNEL_PATH="/boot/vmlinuz-$GUEST_KERNEL"
+	GUEST_INITRD_PATH="/boot/initrd.img-$GUEST_KERNEL"
+	GUEST_CMD_LINE="$GUEST_CMD_LINE_BASE intel_iommu=on,sm_on iommu.strict=1"
+	;;
+nested-vFree)
+	GUEST_KERNEL="6.12.9-iommufd-nested-iova-contig-cb-opt"
+	GUEST_KERNEL_PATH="/boot-VM/vmlinuz-$GUEST_KERNEL"
+	GUEST_INITRD_PATH="/boot-VM/initrd.img-$GUEST_KERNEL"
+	GUEST_CMD_LINE="$GUEST_CMD_LINE_BASE intel_iommu=on,sm_on iommu.strict=1 intel_iommu_pinned=on intel_iommu_dfp=on"
+	;;
+*)
+	echo "Error: unknown --viommu mode '$GUEST_VIOMMU' (expected: off, nested, nested-vFree)" >&2
+	exit 1
+	;;
+esac
+
+# --- Host-side in-tree modules to push into guests ---
+HOST_MLX5_CORE="/lib/modules/$GUEST_KERNEL/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko"
+HOST_MLXFW="/lib/modules/$GUEST_KERNEL/kernel/drivers/net/ethernet/mellanox/mlxfw/mlxfw.ko"
 
 # ============================================================
 # Helper functions
@@ -398,10 +424,14 @@ cleanup() {
 	sudo ./sriov_undo.sh
 
 	# Host reset
-	log_info "Running host reset..."
-	cd "$HOST_SETUP_DIR" || { log_error "Failed to cd to $HOST_SETUP_DIR"; return; }
-	sudo ./reset-host.sh
-	cd "$ORIG_DIR"
+	if [[ "$SKIP_RESET_HOST" -eq 1 ]]; then
+		log_info "Skipping host reset (--skip-reset-host)"
+	else
+		log_info "Running host reset..."
+		cd "$HOST_SETUP_DIR" || { log_error "Failed to cd to $HOST_SETUP_DIR"; return; }
+		sudo ./reset-host.sh
+		cd "$ORIG_DIR"
+	fi
 
 	log_info "=== Cleanup complete ==="
 }
@@ -428,11 +458,11 @@ sudo ./sriov_undo.sh
 if [[ $REUSE -eq 0 ]]; then
 	rm -rf ./generated
 	./xml_generator.sh --kernel "$GUEST_KERNEL_PATH" --initrd "$GUEST_INITRD_PATH" --cmdline "$GUEST_CMD_LINE" \
-		--vcpus $NUM_CORES --num-vms $NUM_VMS --viommu $GUEST_VIOMMU
+		--vcpus $NUM_TOTAL_CORES --num-vms $NUM_VMS --viommu $GUEST_VIOMMU
 fi
 
 timestamp=$(date '+%Y-%m-%d-%H-%M-%S')
-EXP_NAME="${timestamp}-$GUEST_KERNEL-MANY-flow${NUM_FLOWS}-${iommu_config}-${NUM_CORES}cores-${NUM_IPRF}iprf"
+EXP_NAME="${timestamp}-$GUEST_KERNEL-MANY-flow${NUM_FLOWS}-${iommu_config}-${NUM_TOTAL_CORES}cores-${NUM_ACTIVE_CORES}active-cores"
 
 echo "============================================================"
 echo "  VM Benchmark Runner"
@@ -441,8 +471,8 @@ echo "  VMs:       ${NUM_VMS}"
 echo "  XML dir:   ${XML_DIR}"
 echo "  Reuse:     ${REUSE}"
 echo "  Branch:    ${GIT_BRANCH}"
-echo "  Cores:     ${NUM_CORES}"
-echo "  Iperf:     ${NUM_IPRF}"
+echo "  Total Cores:  ${NUM_TOTAL_CORES}"
+echo "  Active Cores: ${NUM_ACTIVE_CORES}"
 echo "  Flows:     ${NUM_FLOWS}"
 echo "  Exp name:  ${EXP_NAME}"
 echo "  MTU:       ${MTU}"
@@ -473,11 +503,6 @@ for ((i = 0; i < NUM_VMS; i++)); do
 	vm_names+=("$vm_name")
 	echo "  VM${i}: ${vm_name}"
 done
-
-# --- Step 3: Destroy any running VMs ---
-echo ""
-log_info "Step 3: Destroying any running VMs..."
-destroy_all_running_vms
 
 # --- Step 4: Define or reuse VMs ---
 echo ""
@@ -612,8 +637,8 @@ fi
 echo ""
 log_info "Step 13: Launching experiments on all VMs..."
 echo "  Script:    ${VM_SCRIPT}"
-echo "  Cores:     ${NUM_CORES}"
-echo "  Iperf:     ${NUM_IPRF}"
+echo "  Total Cores:  ${NUM_TOTAL_CORES}"
+echo "  Active Cores: ${NUM_ACTIVE_CORES}"
 echo "  Flows:     ${NUM_FLOWS}"
 echo "  Exp name:  ${EXP_NAME}"
 echo ""
@@ -623,7 +648,10 @@ for ((i = 0; i < NUM_VMS; i++)); do
 	ip=$(vm_ip "$i")
 	name="${vm_names[$i]}"
 
-	vm_cmd="${VM_SCRIPT} --vm-name ${name} --num-cores ${NUM_IPRF} --num-flows ${NUM_FLOWS} --exp-name ${EXP_NAME}-${name}"
+	vm_cmd="${VM_SCRIPT} --vm-name ${name} --num-cores ${NUM_ACTIVE_CORES} --num-flows ${NUM_FLOWS} \
+		--exp-name ${EXP_NAME}-${name} \
+		--host-ip ${HOST_IP} --host-ssh-uname ${HOST_SSH_UNAME} \
+		--host-home ${HOST_HOME} --host-results-dir ${HOST_RESULTS_DIR}"
 	ssh $SSH_OPTS "$SSH_USER@$ip" "$vm_cmd" &>"${name}_experiment.log" &
 	ssh_pids+=($!)
 	echo "  Launched on ${name} (${ip}), log -> ${name}_experiment.log"
@@ -654,8 +682,18 @@ if [[ "$any_failed" == true ]]; then
 	echo ""
 	log_info "=== Experiment finished with ERRORS (check *_experiment.log files) ==="
 	exit 1
-else
-	echo ""
-	log_info "=== Experiment finished successfully ==="
-	exit 0
 fi
+
+# --- Step 16: Aggregate results from all VMs ---
+echo ""
+log_info "Step 16: Aggregating results from all VMs..."
+REPORT_SCRIPT="${HOST_FandS_ABS}/scripts/many-vm-report-tput-metrics.py"
+SUMMARY_DIR="${HOST_RESULTS_DIR}/${EXP_NAME}"
+
+mkdir -p "$SUMMARY_DIR"
+cd "${HOST_FandS_ABS}/scripts" || true
+python3 "$REPORT_SCRIPT" "$EXP_NAME" tput,cpu "$NUM_VMS" | tee "$SUMMARY_DIR/summary.txt"
+cd "$ORIG_DIR"
+
+log_info "=== Experiment finished successfully ==="
+exit 0

--- a/multi_vms/run_vms.sh
+++ b/multi_vms/run_vms.sh
@@ -28,9 +28,10 @@ GIT_BRANCH="many-vm-setup"
 VM_SCRIPT="cd /home/schai/viommu/scripts/sosp24-experiments; ./many_vm_flows_exp.sh"
 
 # --- Host paths (this script runs ON the host) ---
-HOST_HOME="/home/lbalara"
-HOST_FandS_REL="viommu/ManyVM-FandS"
-HOST_SETUP_DIR="${HOST_HOME}/${HOST_FandS_REL}/utils"
+HOST_FandS_ABS=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+HOST_SETUP_DIR="${HOST_FandS_ABS}/utils"
+echo "Host F&S dir: ${HOST_FandS_ABS}"
+
 
 # --- Client machine config ---
 CLIENT_HOME="/home/siyuanc3"
@@ -196,9 +197,24 @@ vm_ip() {
 	echo "${prefix}.$((base_last_octet + idx))"
 }
 
+VM_DESTROY_WHITELIST=(
+	"server-mini-off"
+)
+
 destroy_all_running_vms() {
 	log_info "Shutting down any running VMs..."
 	for vm in $(virsh list --name 2>/dev/null | grep -v '^$'); do
+		local skip=false
+		for wl in "${VM_DESTROY_WHITELIST[@]}"; do
+			if [[ "$vm" == "$wl" ]]; then
+				skip=true
+				break
+			fi
+		done
+		if $skip; then
+			echo "  Skipping (whitelisted): $vm"
+			continue
+		fi
 		echo "  Destroying: $vm"
 		virsh destroy "$vm" 2>/dev/null || true
 	done
@@ -400,10 +416,15 @@ host_iommu_config=$(parse_iommu_mode "$host_cmdline")
 iommu_config="host-${host_iommu_config}-guest-${GUEST_VIOMMU}"
 echo "iommu_config: $iommu_config"
 
+# --- Step 1: Destroy any running VMs ---
+echo ""
+log_info "Step 1: Destroying any running VMs..."
+destroy_all_running_vms
+
 log_info "Doing sriov undo"
 sudo ./sriov_undo.sh
 
-# --- Step 1: Generate XML files ---
+# --- Step 2: Generate XML files ---
 if [[ $REUSE -eq 0 ]]; then
 	rm -rf ./generated
 	./xml_generator.sh --kernel "$GUEST_KERNEL_PATH" --initrd "$GUEST_INITRD_PATH" --cmdline "$GUEST_CMD_LINE" \
@@ -430,8 +451,8 @@ echo "  Socket buf: ${TCP_SOCKET_BUF_MB} MB"
 echo "============================================================"
 echo ""
 
-# --- Step 2: Discover XML files and VM names ---
-log_info "Step 1: Discovering VM XML files..."
+# --- Step 3: Discover XML files and VM names ---
+log_info "Step 3: Discovering VM XML files..."
 xml_files=()
 for f in "${XML_DIR}"/*.xml; do
 	[[ -f "$f" ]] || continue
@@ -544,6 +565,8 @@ fi
 echo ""
 log_info "Step 10: Waiting for guest NIC ($GUEST_NIC)..."
 failed=0
+# Add sudo so that over users can overwrite
+sudo rm -f /tmp/modules.tar.gz
 tar czf /tmp/modules.tar.gz -C /lib/modules/$GUEST_KERNEL .
 for ((i = 0; i < NUM_VMS; i++)); do
 	ip=$(vm_ip "$i")

--- a/multi_vms/xml_generator.sh
+++ b/multi_vms/xml_generator.sh
@@ -87,10 +87,10 @@ for var in KERNEL INITRD CMDLINE; do
 done
 [[ $err -ne 0 ]] && exit 1
 
-if [[ "$VIOMMU" != "nested" && "$VIOMMU" != "off" ]]; then
-	echo "Error: --viommu must be 'nested' or 'off'" >&2
-	exit 1
-fi
+# if [[ "$VIOMMU" != "nested" && "$VIOMMU" != "off" ]]; then
+# 	echo "Error: --viommu must be 'nested' or 'off'" >&2
+# 	exit 1
+# fi
 
 if [[ "$NUM_VMS" -lt 1 || "$NUM_VMS" -gt "$MAX_VMS" ]]; then
 	echo "Error: --num-vms must be between 1 and $MAX_VMS" >&2

--- a/scripts/many-vm-report-tput-metrics.py
+++ b/scripts/many-vm-report-tput-metrics.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import numpy as np
+
+if len(sys.argv) < 3:
+    print("Usage: python script.py <base_exp_name> <metrics> [num_vms]")
+    print("  metrics: comma-separated list of: tput,cpu,all")
+    print("  num_vms: optional, auto-detected if omitted")
+    sys.exit(1)
+
+# Get the directory where the script is located and change directory
+script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+os.chdir(script_dir)
+
+base_exp_name = sys.argv[1]
+metrics = list(map(str.lower, sys.argv[2].split(",")))
+num_vms = int(sys.argv[3]) if len(sys.argv) > 3 else None
+
+reports_dir = os.path.join("../utils/reports/")
+
+# Auto-detect VM directories matching the base experiment name
+vm_dirs = []
+for entry in sorted(os.listdir(reports_dir)):
+    full_path = os.path.join(reports_dir, entry)
+    if not os.path.isdir(full_path):
+        continue
+    # Match per-VM directories: must start with base_exp_name, have a suffix, and not be a RUN dir
+    suffix = entry[len(base_exp_name):]
+    if entry.startswith(base_exp_name) and suffix and not entry.endswith(("-RUN-0", "-RUN-1", "-RUN-2")):
+        vm_dirs.append(entry)
+
+if num_vms is not None:
+    vm_dirs = vm_dirs[:num_vms]
+
+if not vm_dirs:
+    print(f"No VM directories found matching '{base_exp_name}' in {reports_dir}")
+    sys.exit(1)
+
+# Collect per-VM results
+all_tputs = []
+all_cpus = []
+
+print(f"======= Multi-VM Results: {base_exp_name} =======")
+print(f"VMs found: {len(vm_dirs)}")
+print()
+
+for vm_dir in vm_dirs:
+    metrics_file = os.path.join(reports_dir, vm_dir, "tput_metrics.dat")
+    if not os.path.exists(metrics_file):
+        print(f"--- {vm_dir} ---")
+        print(f"  WARNING: tput_metrics.dat not found")
+        print()
+        continue
+
+    results = np.genfromtxt(metrics_file, dtype=float, delimiter=',', names=True)
+
+    tput = float(results['net_tput_mean'])
+    cpu = float(results['cpu_utils_mean'])
+    all_tputs.append(tput)
+    all_cpus.append(cpu)
+
+    print(f"--- {vm_dir} ---")
+    if "tput" in metrics or "all" in metrics:
+        print(f"  Throughput: {tput:.4f} Gbps")
+    if "cpu" in metrics or "all" in metrics:
+        print(f"  CPU Util:   {cpu:.4f} %")
+    print()
+
+# Aggregate summary
+if all_tputs:
+    print(f"======= Aggregate ({len(all_tputs)} VMs) =======")
+    if "tput" in metrics or "all" in metrics:
+        print(f"  Total Throughput:   {sum(all_tputs):.4f} Gbps")
+        print(f"  Mean Throughput:    {np.mean(all_tputs):.4f} Gbps")
+        if len(all_tputs) > 1:
+            print(f"  Stddev Throughput:  {np.std(all_tputs, ddof=1):.4f} Gbps")
+    if "cpu" in metrics or "all" in metrics:
+        print(f"  Mean CPU Util:      {np.mean(all_cpus):.4f} %")
+        if len(all_cpus) > 1:
+            print(f"  Stddev CPU Util:    {np.std(all_cpus, ddof=1):.4f} %")
+    print()

--- a/scripts/many-vm-run-dctcp-tput-experiment.sh
+++ b/scripts/many-vm-run-dctcp-tput-experiment.sh
@@ -413,6 +413,8 @@ iova_ftrace_guest_output_file="${current_guest_reports_dir}/iova_ftrace_guest.tx
 ebpf_guest_stats="${current_guest_reports_dir}/ebpf_guest_stats.csv"
 guest_server_app_log_file="${current_guest_reports_dir}/server_app.log"
 guest_mlc_log_file="${current_guest_reports_dir}/mlc.log"
+client_app_log_file="${current_guest_reports_dir}/client_app.log"
+client_app_log_file_remote="${client_reports_dir_remote}/client_app.log"
 
 sudo mkdir -p "$current_guest_reports_dir"
 
@@ -462,8 +464,8 @@ cd - > /dev/null
 
 # --- Start Clients (traffic generation only, no client setup-envir.sh) ---
 # Uses VM-specific screen session name and port offset.
-log_info "Starting CLIENT traffic on $CLIENT_SSH_HOST (screen: $SCREEN_CLIENT_SESSION, port: $INIT_PORT)..."
-client_cmd="cd '$CLIENT_EXP_DIR'; sudo bash many-run-netapp-tput.sh --mode client --server-ip '$GUEST_IP' -n '$GUEST_NUM_SERVERS' -N '$CLIENT_NUM_CLIENTS' -o '${EXP_NAME}-RUN-${j}' -p '$INIT_PORT' -c '$CLIENT_CPU_MASK' -b '$CLIENT_BANDWIDTH'; exec bash"
+log_info "Starting CLIENT traffic on $CLIENT_SSH_HOST (screen: $SCREEN_CLIENT_SESSION, port: $INIT_PORT); logs at $client_app_log_file_remote..."
+client_cmd="mkdir -p '$client_reports_dir_remote'; cd '$CLIENT_EXP_DIR'; sudo bash many-run-netapp-tput.sh --mode client --server-ip '$GUEST_IP' -n '$GUEST_NUM_SERVERS' -N '$CLIENT_NUM_CLIENTS' -o '${EXP_NAME}-RUN-${j}' -p '$INIT_PORT' -c '$CLIENT_CPU_MASK' -b '$CLIENT_BANDWIDTH' &>'$client_app_log_file_remote'; exec bash"
 $SSH_CLIENT_CMD "screen -dmS $SCREEN_CLIENT_SESSION sudo bash -c \"$client_cmd\""
 
 # --- Warmup Phase ---
@@ -538,10 +540,16 @@ if [ "$CLIENT_USE_PASS_AUTH" -eq 1 ]; then
 	sshpass -p "$CLIENT_SSH_PASSWORD" \
 		scp "${CLIENT_SSH_UNAME}@${CLIENT_SSH_HOST}:${client_reports_dir_remote}/retx.rpt" \
 		"${current_guest_reports_dir}/client-retx.rpt" || log_error "Failed to SCP client retx.rpt"
+	sshpass -p "$CLIENT_SSH_PASSWORD" \
+		scp "${CLIENT_SSH_UNAME}@${CLIENT_SSH_HOST}:${client_app_log_file_remote}" \
+		"$client_app_log_file" || log_error "Failed to SCP client_app.log"
 else
 	scp -i "$CLIENT_SSH_IDENTITY_FILE" \
 		"${CLIENT_SSH_UNAME}@${CLIENT_SSH_HOST}:${client_reports_dir_remote}/retx.rpt" \
 		"${current_guest_reports_dir}/client-retx.rpt" || log_error "Failed to SCP client retx.rpt"
+	scp -i "$CLIENT_SSH_IDENTITY_FILE" \
+		"${CLIENT_SSH_UNAME}@${CLIENT_SSH_HOST}:${client_app_log_file_remote}" \
+		"$client_app_log_file" || log_error "Failed to SCP client_app.log"
 fi
 
 log_info "Waiting for remote operations to settle ($((CORE_DURATION_S * 2))s)..."

--- a/scripts/sosp24-experiments/many_vm_flows_exp.sh
+++ b/scripts/sosp24-experiments/many_vm_flows_exp.sh
@@ -12,20 +12,29 @@ NUM_CORES=""
 NUM_FLOWS=""
 DRY_RUN=0
 EXP_NAME=""
+HOST_IP_ARG=""
+HOST_SSH_UNAME_ARG=""
+HOST_HOME_ARG=""
+HOST_RESULTS_DIR_ARG=""
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-	--vm-name)    VM_NAME="$2";    shift 2 ;;
-	--num-cores)  NUM_CORES="$2";  shift 2 ;;
-	--num-flows)  NUM_FLOWS="$2";  shift 2 ;;
-	--exp-name)   EXP_NAME="$2";   shift 2 ;;
-	--dry)        DRY_RUN=1;       shift   ;;
-	*)            shift            ;;
+	--vm-name)          VM_NAME="$2";              shift 2 ;;
+	--num-cores)        NUM_CORES="$2";            shift 2 ;;
+	--num-flows)        NUM_FLOWS="$2";            shift 2 ;;
+	--exp-name)         EXP_NAME="$2";             shift 2 ;;
+	--host-ip)          HOST_IP_ARG="$2";          shift 2 ;;
+	--host-ssh-uname)   HOST_SSH_UNAME_ARG="$2";   shift 2 ;;
+	--host-home)        HOST_HOME_ARG="$2";        shift 2 ;;
+	--host-results-dir) HOST_RESULTS_DIR_ARG="$2"; shift 2 ;;
+	--dry)              DRY_RUN=1;                 shift   ;;
+	*)                  shift                      ;;
 	esac
 done
 
 if [[ -z "$VM_NAME" || -z "$NUM_CORES" || -z "$NUM_FLOWS" || -z "$EXP_NAME" ]]; then
 	echo "Usage: $0 --vm-name <n> --num-cores <N> --num-flows <N> --exp-name <name> [--dry]" >&2
+	echo "  Optional: --host-ip <ip> --host-ssh-uname <user> --host-home <path> --host-results-dir <path>" >&2
 	exit 1
 fi
 
@@ -49,10 +58,10 @@ GUEST_IP="192.168.101.$((11 + VM_INDEX))"
 GUEST_NIC_BUS="0x0"
 GUEST_HOME="/home/schai"
 
-HOST_IP="192.17.101.97"
-HOST_UNAME="lbalara"
-HOST_HOME="/home/lbalara"
-HOST_RESULTS_DIR="/home/lbalara/viommu/ManyVM-FandS/utils/reports/"
+HOST_IP="${HOST_IP_ARG:-192.17.101.97}"
+HOST_SSH_UNAME="${HOST_SSH_UNAME_ARG:-lbalara}"
+HOST_HOME="${HOST_HOME_ARG:-/home/lbalara}"
+HOST_RESULTS_DIR="${HOST_RESULTS_DIR_ARG:-/home/lbalara/viommu/ManyVM-FandS/utils/reports/}"
 
 CLIENT_HOME="/home/siyuanc3"
 CLIENT_INTF="ens1006np0"
@@ -63,7 +72,6 @@ CLIENT_SSH_PASSWORD="saksham"
 CLIENT_USE_PASS_AUTH=0
 CLIENT_SSH_IDENTITY_FILE="/home/schai/.ssh/id_rsa"
 
-HOST_SSH_UNAME="lbalara"
 HOST_SSH_PASSWORD=""
 HOST_SSH_IDENTITY_FILE="/home/schai/.ssh/id_rsa"
 HOST_USE_PASS_AUTH=0


### PR DESCRIPTION
- HOST_SETUP_DIR no longer hardcoded.
- Destroy VMs run first to avoid sr iov script from getting stuck
- Add whitelist to kill all VMs
- Remove modules.tar.gz to avoid permission issue.
- Expose guestVIOMMU option to external script
- Optionally skip SMT reset (too slow, 1min per set).
- Rename NUM_IPERF and NUM_CORES to NUM_ACTIVE_CORES and NUM_TOTAL_CORES
- Add script to summarize all VM results in the end.